### PR TITLE
Using git add -A instead of add . to also respect deleted files.

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -163,7 +163,7 @@ class BuildCommand extends Tasks {
     $commit_hash = trim($commit_hash);
 
     $task = $this->taskGitStack()
-      ->exec("add '.'")
+      ->exec("add -A")
       // Note that git commit uses ' already, so we remove ours. Also, we allow
       // empty commits in case no assets were changed the merge might be enough.
       ->commit(sprintf("Build %s commit %s.", trim($branch, '\''), trim($commit_hash, '\'')), '--allow-empty');


### PR DESCRIPTION
Using git -A instead of . allows to also track deleted files that had been staged before, see:
http://stackoverflow.com/questions/572549/difference-between-git-add-a-and-git-add#572660